### PR TITLE
ewah_bitmap.c: update max_size() func

### DIFF
--- a/ewah_bitmap.c
+++ b/ewah_bitmap.c
@@ -33,7 +33,7 @@ static inline size_t min_size(size_t a, size_t b)
 
 static inline size_t max_size(size_t a, size_t b)
 {
-	return a < b ? a : b;
+	return a > b ? a : b;
 }
 
 static inline void buffer_grow(struct ewah_bitmap *self, size_t new_size)


### PR DESCRIPTION
Fix a little bug, and I find it is OK in git/ewah/ewah_bitmap.c 
:-)
